### PR TITLE
Revamp portfolio layout and navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -87,38 +87,35 @@
         position: sticky;
         top: 0;
         z-index: 50;
-        backdrop-filter: blur(18px);
-        background: rgba(253, 249, 245, 0.82);
-        border-bottom: 1px solid rgba(216, 160, 168, 0.25);
-        display: grid;
-        grid-template-columns: auto 1fr auto;
+        display: flex;
         align-items: center;
-        padding: 1.4rem clamp(1.5rem, 4vw, 3rem);
-        gap: 1rem;
+        justify-content: space-between;
+        padding: 1.2rem clamp(1.5rem, 4vw, 3rem);
+        background: var(--magnolia-50);
+        border-bottom: 1px solid rgba(216, 160, 168, 0.25);
       }
 
       .logo {
-        font-size: 1.15rem;
+        font-size: 1.2rem;
         font-weight: 700;
         letter-spacing: 0.08em;
         text-transform: uppercase;
+        color: var(--ink);
       }
 
       .menu-toggle {
         position: relative;
-        width: 46px;
-        height: 46px;
-        border-radius: 50%;
-        border: 1px solid rgba(216, 160, 168, 0.4);
-        background: rgba(255, 255, 255, 0.75);
+        width: 44px;
+        height: 44px;
+        border-radius: 999px;
+        border: 1px solid rgba(216, 160, 168, 0.45);
+        background: transparent;
         display: inline-flex;
         align-items: center;
         justify-content: center;
         cursor: pointer;
-        transition:
-          transform 0.2s ease,
-          box-shadow 0.25s ease;
-        box-shadow: 0 12px 25px rgba(31, 27, 24, 0.14);
+        transition: transform 0.2s ease, border-color 0.2s ease;
+        box-shadow: none;
       }
 
       .menu-toggle:focus-visible,
@@ -129,7 +126,7 @@
 
       .menu-toggle:hover {
         transform: translateY(-2px);
-        box-shadow: 0 16px 30px rgba(31, 27, 24, 0.18);
+        border-color: rgba(216, 160, 168, 0.7);
       }
 
       .menu-toggle__line,
@@ -207,13 +204,6 @@
         justify-content: space-between;
         border-bottom: 1px solid rgba(216, 160, 168, 0.25);
         transition: color 0.2s ease;
-      }
-
-      .site-nav a span {
-        font-size: 0.8rem;
-        letter-spacing: 0.08em;
-        text-transform: uppercase;
-        color: rgba(63, 56, 48, 0.5);
       }
 
       .site-nav a:hover,
@@ -324,6 +314,11 @@
         font-size: 1.05rem;
         color: var(--muted);
         line-height: 1.65;
+      }
+
+      .hero-highlight {
+        color: rgba(120, 117, 255, 0.9);
+        font-weight: 600;
       }
 
       .btn {
@@ -514,579 +509,256 @@
         backdrop-filter: saturate(135%) blur(22px);
       }
 
-      .portfolio-shell {
+      .portfolio-layout {
         display: grid;
-        gap: clamp(1.5rem, 4vw, 2.5rem);
-        grid-template-columns: minmax(0, 1.4fr) minmax(0, 0.85fr);
-        align-items: stretch;
+        gap: clamp(1.5rem, 4vw, 2.75rem);
+        grid-template-columns: minmax(0, 0.95fr) minmax(0, 1.35fr);
+        align-items: start;
         margin-top: clamp(2.4rem, 4vw, 3rem);
       }
 
-      @media (max-width: 960px) {
-        .portfolio-shell {
+      @media (max-width: 1024px) {
+        .portfolio-layout {
           grid-template-columns: 1fr;
         }
       }
 
-      .project-showcase {
-        position: relative;
-        overflow: hidden;
-        padding: clamp(2.2rem, 3vw, 2.8rem);
+      .project-tiles {
         display: flex;
         flex-direction: column;
-        justify-content: space-between;
-        gap: clamp(1.5rem, 3vw, 2.1rem);
-        isolation: isolate;
+        gap: 1rem;
       }
 
-      .project-showcase::before {
-        content: "";
-        position: absolute;
-        inset: -10%;
-        background: linear-gradient(
-          140deg,
-          rgba(216, 160, 168, 0.4),
-          rgba(120, 117, 255, 0.35)
-        );
-        opacity: 0.7;
-        filter: blur(40px);
-        z-index: -2;
-        animation: pulse 14s ease-in-out infinite;
+      .project-tile {
+        border-radius: 24px;
+        border: 1px solid rgba(216, 160, 168, 0.35);
+        background: rgba(255, 255, 255, 0.78);
+        padding: 1.6rem;
+        display: flex;
+        flex-direction: column;
+        gap: 0.85rem;
+        text-align: left;
+        cursor: pointer;
+        transition: transform 0.2s ease, box-shadow 0.25s ease,
+          border-color 0.25s ease;
       }
 
-      .project-showcase::after {
-        content: "";
-        position: absolute;
-        inset: 0;
-        background: linear-gradient(
-          160deg,
-          rgba(255, 255, 255, 0.86),
-          rgba(255, 255, 255, 0.25)
-        );
-        z-index: -1;
+      .project-tile:hover,
+      .project-tile:focus-visible {
+        transform: translateY(-4px);
+        border-color: rgba(120, 117, 255, 0.45);
+        box-shadow: 0 18px 35px rgba(31, 27, 24, 0.16);
+        outline: none;
       }
 
-      @keyframes pulse {
-        0%,
-        100% {
-          transform: scale(1) translate3d(0, 0, 0);
-        }
-        50% {
-          transform: scale(1.04) translate3d(2%, -1%, 0);
-        }
+      .project-tile.active {
+        border-color: rgba(120, 117, 255, 0.55);
+        box-shadow: 0 22px 45px rgba(31, 27, 24, 0.18);
       }
 
-      .project-showcase__visual {
-        position: relative;
-        width: 100%;
-        border-radius: 22px;
+      .project-tile h3 {
+        margin: 0;
+        font-size: 1.2rem;
+        color: var(--ink);
+      }
+
+      .project-tile p {
+        margin: 0;
+        color: var(--muted);
+        font-size: 0.95rem;
+        line-height: 1.55;
+      }
+
+      .project-tile figure {
+        margin: 0;
+        border-radius: 18px;
         overflow: hidden;
-        aspect-ratio: 16 / 9;
-        border: 1px solid rgba(255, 255, 255, 0.45);
-        box-shadow: 0 25px 45px rgba(31, 27, 24, 0.22);
+        border: 1px solid rgba(216, 160, 168, 0.35);
+        aspect-ratio: 4 / 3;
         background: rgba(253, 249, 245, 0.75);
       }
 
-      .project-showcase__visual img {
+      .project-tile img {
         width: 100%;
         height: 100%;
         object-fit: cover;
+        display: block;
       }
 
-      .project-showcase__title {
-        font-size: clamp(1.85rem, 1.4rem + 1vw, 2.15rem);
-        margin: 0;
-        color: var(--ink);
-      }
-
-      .project-showcase__summary {
-        color: rgba(63, 56, 48, 0.75);
-        line-height: 1.6;
-        font-size: 1rem;
-        max-width: 60ch;
-      }
-
-      .project-showcase__outcome {
-        margin-top: 0.75rem;
-        font-size: 0.95rem;
-        font-weight: 600;
-        color: rgba(63, 56, 48, 0.76);
-      }
-
-      .metrics-grid {
-        display: flex;
-        gap: 1rem;
-        flex-wrap: wrap;
-      }
-
-      .metric-tile {
-        flex: 1 1 140px;
-        padding: 1rem 1.2rem;
-        border-radius: 18px;
-        border: 1px solid rgba(255, 255, 255, 0.6);
-        background: rgba(255, 255, 255, 0.55);
-        box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
-        position: relative;
-        overflow: hidden;
-      }
-
-      .metric-tile::after {
-        content: "";
-        position: absolute;
-        inset: auto -40% -45% 50%;
-        width: 140%;
-        height: 120%;
-        background: radial-gradient(
-          circle,
-          rgba(216, 160, 168, 0.4),
-          transparent 70%
-        );
-        transform: translate(-50%, -20%);
-        opacity: 0.6;
-        pointer-events: none;
-      }
-
-      .metric-value {
-        font-size: 1.4rem;
-        font-weight: 700;
-        color: var(--ink);
-        margin-bottom: 0.35rem;
-        position: relative;
-        z-index: 1;
-      }
-
-      .metric-label {
-        font-size: 0.78rem;
-        text-transform: uppercase;
-        letter-spacing: 0.12em;
-        color: rgba(63, 56, 48, 0.65);
-        position: relative;
-        z-index: 1;
-      }
-
-      .project-showcase__cta {
-        display: flex;
-        align-items: center;
-        gap: 0.5rem;
-        font-weight: 600;
-        color: var(--ink);
-        text-decoration: none;
-      }
-
-      .project-showcase__cta svg {
-        width: 18px;
-        height: 18px;
-      }
-
-      .project-catalog {
-        padding: clamp(1.6rem, 2vw, 2rem);
-        display: flex;
-        flex-direction: column;
-        gap: 1rem;
-      }
-
-      .catalog-card {
-        position: relative;
-        padding: 1.25rem 1.35rem;
-        border-radius: 20px;
-        border: 1px solid rgba(255, 255, 255, 0.55);
-        background: rgba(255, 255, 255, 0.6);
-        box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
-        cursor: pointer;
-        transition:
-          transform 0.22s ease,
-          box-shadow 0.24s ease,
-          border-color 0.24s ease;
-        display: grid;
-        gap: 0.35rem;
-        font: inherit;
-        color: inherit;
-        text-align: left;
-      }
-
-      .catalog-card:hover,
-      .catalog-card:focus-visible {
-        transform: translateY(-4px);
-        border-color: rgba(216, 160, 168, 0.55);
-        box-shadow: 0 18px 30px rgba(31, 27, 24, 0.16);
-      }
-
-      .catalog-card:focus-visible {
-        outline: 3px solid rgba(216, 160, 168, 0.45);
-        outline-offset: 3px;
-      }
-
-      .catalog-card.active {
-        border-color: rgba(216, 160, 168, 0.7);
-        box-shadow: 0 20px 40px rgba(31, 27, 24, 0.18);
-        background: linear-gradient(
-          160deg,
-          rgba(255, 255, 255, 0.85),
-          rgba(216, 160, 168, 0.18)
-        );
-      }
-
-      .catalog-card__eyebrow {
-        font-size: 0.7rem;
-        letter-spacing: 0.18em;
-        text-transform: uppercase;
-        color: rgba(63, 56, 48, 0.55);
-        font-weight: 700;
-      }
-
-      .catalog-card h4 {
-        margin: 0;
-        font-size: 1.1rem;
-        font-weight: 700;
-        color: var(--ink);
-      }
-
-      .catalog-card p {
-        margin: 0;
-        font-size: 0.88rem;
-        color: rgba(63, 56, 48, 0.7);
-      }
-
-      .catalog-card__cta {
-        font-size: 0.78rem;
-        text-transform: uppercase;
-        letter-spacing: 0.16em;
-        color: rgba(216, 160, 168, 0.9);
-        font-weight: 700;
-      }
-
-      .project-depth {
+      .project-detail {
         padding: clamp(2.2rem, 3vw, 2.8rem);
-        display: grid;
-        gap: clamp(2rem, 4vw, 2.8rem);
-        margin-top: clamp(2rem, 4vw, 3rem);
-      }
-
-      .focus-chips {
-        display: flex;
-        flex-wrap: wrap;
-        gap: 0.7rem;
-      }
-
-      .focus-chips span {
-        display: inline-flex;
-        align-items: center;
-        gap: 0.4rem;
-        padding: 0.55rem 1.1rem;
-        border-radius: 999px;
-        border: 1px solid rgba(216, 160, 168, 0.4);
-        background: rgba(255, 255, 255, 0.7);
-        color: var(--muted);
-        font-size: 0.85rem;
-        font-weight: 600;
-      }
-
-      .detail-panel {
+        border-radius: 28px;
+        border: 1px solid rgba(255, 255, 255, 0.35);
+        box-shadow: 0 24px 55px rgba(31, 27, 24, 0.14);
+        background: rgba(255, 255, 255, 0.82);
         display: flex;
         flex-direction: column;
         gap: 1.75rem;
-        padding: clamp(1.6rem, 1.3rem + 1vw, 2.1rem);
+        min-height: 100%;
+      }
+
+      .project-detail header {
+        display: flex;
+        flex-direction: column;
+        gap: 0.4rem;
+      }
+
+      .project-detail header h3 {
+        margin: 0;
+        font-size: clamp(1.65rem, 1.3rem + 1vw, 2.1rem);
+        color: var(--ink);
+      }
+
+      .project-detail header p {
+        margin: 0;
+        color: var(--muted);
       }
 
       .detail-metrics {
         display: grid;
         gap: 1rem;
-        grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+        grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
       }
 
-      .detail-metric {
-        display: flex;
-        flex-direction: column;
-        gap: 0.25rem;
-        padding: 1rem 1.2rem;
-        border-radius: 18px;
-        border: 1px solid rgba(255, 255, 255, 0.6);
-        background: rgba(255, 255, 255, 0.55);
-        box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.65);
+      .metric-card {
+        background: rgba(0, 0, 0, 0.03);
+        border-radius: 16px;
+        padding: 1.1rem 1.25rem;
+        text-align: left;
+        border: 1px solid rgba(216, 160, 168, 0.25);
       }
 
-      .detail-metric__value {
-        font-size: 1.15rem;
+      .metric-card-value {
+        font-size: 1.45rem;
         font-weight: 700;
         color: var(--ink);
       }
 
-      .detail-metric__label {
-        font-size: 0.82rem;
+      .metric-card-label {
+        font-size: 0.8rem;
         text-transform: uppercase;
-        letter-spacing: 0.08em;
-        color: rgba(63, 56, 48, 0.55);
+        letter-spacing: 0.14em;
+        color: rgba(63, 56, 48, 0.65);
       }
 
-      .detail-tabs {
+      .details-tabs {
         display: flex;
         flex-wrap: wrap;
-        gap: 0.65rem;
+        gap: 0.6rem;
       }
 
-      .detail-tab {
-        border: 1px solid rgba(216, 160, 168, 0.35);
-        background: rgba(255, 255, 255, 0.75);
+      .details-tabs button {
+        padding: 0.55rem 1.1rem;
         border-radius: 999px;
-        padding: 0.45rem 0.95rem;
-        font-weight: 600;
-        font-size: 0.85rem;
-        letter-spacing: 0.04em;
-        text-transform: uppercase;
+        border: 1px solid transparent;
+        background: rgba(0, 0, 0, 0.04);
         color: var(--muted);
-        cursor: pointer;
-        transition:
-          transform 0.18s ease,
-          box-shadow 0.25s ease,
-          background 0.25s ease;
-      }
-
-      .detail-tab.is-active {
-        color: var(--ink);
-        background: linear-gradient(
-          135deg,
-          rgba(216, 160, 168, 0.22),
-          rgba(120, 117, 255, 0.18)
-        );
-        box-shadow: 0 10px 25px rgba(31, 27, 24, 0.15);
-      }
-
-      .detail-tab:hover {
-        transform: translateY(-1px);
-      }
-
-      .detail-content {
-        display: block;
-      }
-
-      .detail-pane {
-        display: none;
-        color: rgba(63, 56, 48, 0.78);
-        line-height: 1.7;
-      }
-
-      .detail-pane.is-active {
-        display: block;
-      }
-
-      .methodology-container {
-        display: grid;
-        gap: 1.4rem;
-        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-      }
-
-      .methodology-item {
-        padding: 1.1rem 1.25rem;
-        border-radius: 18px;
-        border: 1px solid rgba(216, 160, 168, 0.25);
-        background: rgba(255, 255, 255, 0.78);
-        box-shadow: 0 12px 28px rgba(31, 27, 24, 0.14);
-      }
-
-      .tag-badge {
-        display: inline-flex;
-        align-items: center;
-        justify-content: center;
-        padding: 0.35rem 0.75rem;
-        border-radius: 999px;
-        border: 1px solid rgba(216, 160, 168, 0.35);
-        background: rgba(255, 255, 255, 0.85);
-        font-size: 0.75rem;
         font-weight: 600;
-        color: rgba(63, 56, 48, 0.68);
+        cursor: pointer;
+        transition: background 0.2s ease, color 0.2s ease,
+          border-color 0.2s ease;
       }
 
-      .stat-card {
-        border-radius: 18px;
-        border: 1px solid rgba(216, 160, 168, 0.25);
-        padding: 1.1rem 1.25rem;
-        background: rgba(255, 255, 255, 0.75);
-        text-align: center;
-        box-shadow: 0 12px 28px rgba(31, 27, 24, 0.14);
-      }
-
-      .stat-number {
-        font-size: 1.4rem;
-        font-weight: 700;
+      .details-tabs button.active {
+        background: rgba(120, 117, 255, 0.12);
+        border-color: rgba(120, 117, 255, 0.35);
         color: var(--ink);
       }
 
-      .stat-description {
-        font-size: 0.85rem;
-        color: rgba(63, 56, 48, 0.6);
+      .tab-content {
+        display: none;
+      }
+
+      .tab-content.active {
+        display: block;
+        animation: fadeIn 0.4s ease;
+      }
+
+      .tab-panels {
+        display: grid;
+        gap: 1.2rem;
+      }
+
+      .detail-copy {
+        display: grid;
+        gap: 1rem;
+        color: var(--muted);
+      }
+
+      .detail-copy h4 {
+        margin: 0 0 0.5rem;
+        font-size: 1.1rem;
+        color: var(--ink);
+      }
+
+      .detail-copy ul {
+        margin: 0;
+        padding-left: 1.2rem;
+        display: grid;
+        gap: 0.4rem;
+      }
+
+      .detail-copy p,
+      .detail-copy li {
+        line-height: 1.6;
+      }
+
+      .project-tile .project-outcome strong {
+        color: rgba(120, 117, 255, 0.75);
+        margin-right: 0.35rem;
+      }
+
+      .media-featured {
+        border-radius: 22px;
+        overflow: hidden;
+        border: 1px solid rgba(216, 160, 168, 0.35);
+        aspect-ratio: 16 / 9;
+        background: rgba(253, 249, 245, 0.75);
+      }
+
+      .media-featured img {
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+        display: block;
       }
 
       .media-carousel {
         position: relative;
         overflow: hidden;
-        border-radius: 24px;
-        border: 1px solid rgba(255, 255, 255, 0.55);
-        background: rgba(255, 255, 255, 0.6);
-        box-shadow: 0 18px 36px rgba(31, 27, 24, 0.16);
-        min-height: 260px;
-        isolation: isolate;
-      }
-
-      .media-carousel__slides {
-        position: relative;
-        width: 100%;
-        height: 100%;
-      }
-
-      .media-slide {
-        position: absolute;
-        inset: 0;
-        opacity: 0;
-        transition: opacity 0.7s ease;
-        display: grid;
-        grid-template-rows: 1fr auto;
-      }
-
-      .media-carousel[data-empty="true"] .media-slide {
-        place-items: center;
-        padding: 2.4rem;
-        background: rgba(255, 255, 255, 0.8);
-        color: rgba(63, 56, 48, 0.6);
-        text-align: center;
-        font-size: 0.9rem;
-        line-height: 1.5;
-      }
-
-      .media-slide.is-active {
-        opacity: 1;
-        z-index: 1;
-      }
-
-      .media-slide img {
-        width: 100%;
-        height: 100%;
-        object-fit: cover;
-      }
-
-      .media-caption {
-        padding: 1rem 1.25rem;
-        font-size: 0.85rem;
-        color: rgba(63, 56, 48, 0.75);
-        background: linear-gradient(
-          180deg,
-          rgba(255, 255, 255, 0.92),
-          rgba(255, 255, 255, 0.75)
-        );
-      }
-
-      .media-grid__item {
-        display: flex;
-        flex-direction: column;
-        gap: 0.5rem;
         border-radius: 18px;
+        border: 1px solid rgba(216, 160, 168, 0.25);
+      }
+
+      .media-carousel__track {
+        display: flex;
+        gap: 1.5rem;
+        width: max-content;
+        padding: 1rem;
+        animation: mediaSlide 24s linear infinite;
+      }
+
+      .media-carousel__item {
+        width: clamp(200px, 28vw, 260px);
+        border-radius: 16px;
         overflow: hidden;
-        border: 1px solid rgba(255, 255, 255, 0.6);
-        background: rgba(255, 255, 255, 0.75);
-        box-shadow: 0 14px 32px rgba(31, 27, 24, 0.12);
+        border: 1px solid rgba(216, 160, 168, 0.35);
+        background: rgba(253, 249, 245, 0.75);
+        flex-shrink: 0;
       }
 
-      .media-grid__item img {
+      .media-carousel__item img {
         width: 100%;
-        height: auto;
-        display: block;
+        height: 100%;
         object-fit: cover;
+        display: block;
       }
 
-      .media-grid__item figcaption {
-        padding: 0.85rem 1rem;
-        font-size: 0.85rem;
-        color: rgba(63, 56, 48, 0.65);
+      @keyframes mediaSlide {
+        to {
+          transform: translateX(-50%);
+        }
       }
-
-      .media-controls {
-        position: absolute;
-        inset: auto 1.25rem 1.25rem;
-        display: flex;
-        align-items: center;
-        gap: 0.6rem;
-        background: rgba(255, 255, 255, 0.85);
-        border-radius: 999px;
-        padding: 0.35rem 0.7rem;
-        box-shadow: 0 10px 22px rgba(31, 27, 24, 0.15);
-      }
-
-      .media-controls button {
-        border: none;
-        background: transparent;
-        color: var(--ink);
-        display: grid;
-        place-items: center;
-        width: 32px;
-        height: 32px;
-        border-radius: 50%;
-        cursor: pointer;
-        transition:
-          transform 0.2s ease,
-          background 0.2s ease;
-      }
-
-      .media-controls button:hover,
-      .media-controls button:focus-visible {
-        background: rgba(216, 160, 168, 0.2);
-        transform: translateY(-1px);
-      }
-
-      .media-dots {
-        display: flex;
-        gap: 0.35rem;
-      }
-
-      .media-dot {
-        width: 9px;
-        height: 9px;
-        border-radius: 50%;
-        background: rgba(63, 56, 48, 0.22);
-        border: none;
-        padding: 0;
-        cursor: pointer;
-        transition:
-          transform 0.2s ease,
-          background 0.2s ease;
-      }
-
-      .media-dot.is-active {
-        background: rgba(216, 160, 168, 0.9);
-        transform: scale(1.2);
-      }
-
-      .insight-grid {
-        display: grid;
-        gap: 1.2rem;
-        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-      }
-
-      .insight-card {
-        border-radius: 20px;
-        border: 1px solid rgba(255, 255, 255, 0.55);
-        background: rgba(255, 255, 255, 0.68);
-        padding: 1.4rem 1.6rem;
-        display: grid;
-        gap: 0.55rem;
-        box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.7);
-      }
-
-      .insight-card__icon {
-        font-size: 1.2rem;
-        margin-right: 0.35rem;
-      }
-
-      .insight-card strong {
-        font-size: 0.95rem;
-        color: var(--ink);
-      }
-
-      .insight-card p {
-        margin: 0;
-        font-size: 0.88rem;
-        color: rgba(63, 56, 48, 0.72);
-        line-height: 1.55;
-      }
-
       .cta-section {
         display: grid;
         grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
@@ -1098,6 +770,99 @@
         padding: clamp(2rem, 3vw, 2.5rem);
         display: grid;
         gap: 1.2rem;
+      }
+
+      .skills-section {
+        display: grid;
+        gap: clamp(2rem, 4vw, 2.8rem);
+      }
+
+      .skills-grid {
+        display: grid;
+        gap: 1.6rem;
+        grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+      }
+
+      .skill-card {
+        border-radius: 24px;
+        border: 1px solid rgba(216, 160, 168, 0.3);
+        background: rgba(255, 255, 255, 0.82);
+        padding: 1.8rem;
+        display: grid;
+        gap: 0.9rem;
+      }
+
+      .skill-card h3 {
+        margin: 0;
+        font-size: 1.15rem;
+        color: var(--ink);
+      }
+
+      .skill-card p {
+        margin: 0;
+        color: var(--muted);
+        line-height: 1.6;
+      }
+
+      .skill-card ul {
+        margin: 0;
+        padding-left: 1.1rem;
+        display: grid;
+        gap: 0.4rem;
+        color: var(--muted);
+      }
+
+      .contact-section {
+        display: flex;
+        justify-content: center;
+      }
+
+      .contact-panel {
+        width: 100%;
+        padding: clamp(2.2rem, 3vw, 3rem);
+        display: grid;
+        gap: 1.6rem;
+      }
+
+      .contact-grid {
+        display: grid;
+        gap: 1rem;
+        grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+      }
+
+      .contact-card {
+        border-radius: 18px;
+        border: 1px solid rgba(216, 160, 168, 0.35);
+        background: rgba(255, 255, 255, 0.85);
+        padding: 1.4rem 1.6rem;
+        display: grid;
+        gap: 0.6rem;
+        text-decoration: none;
+        color: var(--ink);
+        transition: transform 0.2s ease, box-shadow 0.25s ease,
+          border-color 0.25s ease;
+      }
+
+      .contact-card span {
+        font-size: 0.78rem;
+        letter-spacing: 0.18em;
+        text-transform: uppercase;
+        color: rgba(120, 117, 255, 0.8);
+        font-weight: 700;
+      }
+
+      .contact-card p {
+        margin: 0;
+        color: var(--muted);
+        line-height: 1.55;
+      }
+
+      .contact-card:hover,
+      .contact-card:focus-visible {
+        transform: translateY(-4px);
+        border-color: rgba(120, 117, 255, 0.45);
+        box-shadow: 0 18px 35px rgba(31, 27, 24, 0.16);
+        outline: none;
       }
 
       .testimonial-wrapper {
@@ -1197,7 +962,6 @@
     <div class="content-layer">
       <header class="site-header">
         <div class="logo">Sphoorthy Masa</div>
-        <div class="header-spacer" aria-hidden="true"></div>
         <button
           class="menu-toggle"
           type="button"
@@ -1221,23 +985,21 @@
           &times;
         </button>
         <div class="site-nav__title">Navigate</div>
-        <a href="#about">About<span>Journey</span></a>
-        <a href="#portfolio">Portfolio<span>Case studies</span></a>
-        <a href="#why-me-contact">Contact<span>Partner</span></a>
+        <a href="#portfolio">Portfolio</a>
+        <a href="#skills">Skills</a>
+        <a href="#contact">Contact</a>
       </nav>
       <div class="menu-backdrop" data-menu-backdrop></div>
 
       <main class="site-main">
-        <section id="about" class="hero reveal">
+        <section id="intro" class="hero reveal">
           <div>
-            <p class="hero-eyebrow">Evidence-driven ux research leader</p>
-            <h1>
-              I turn complex ecosystems into clear, measurable product bets.
-            </h1>
+            <p class="hero-eyebrow">Purpose-built research for meaningful experiences</p>
+            <h1>Senior UX Researcher</h1>
             <p>
-              From vision work to launch, I blend qualitative craft, data
-              fluency, and executive storytelling to unlock bold, accountable
-              product decisions.
+              Bringing <span class="hero-highlight">clarity to complexity</span>
+              through user-centric insights that drive product strategy and
+              business growth.
             </p>
             <div class="hero-stats">
               <dl class="hero-stat">
@@ -1283,39 +1045,69 @@
             </p>
           </div>
 
-          <div class="portfolio-shell">
-            <article
-              id="project-showcase"
-              class="glass-panel project-showcase"
+          <div class="portfolio-layout">
+            <div
+              id="project-tiles"
+              class="project-tiles"
+              aria-label="Project list"
+            ></div>
+            <div
+              id="project-detail"
+              class="project-detail panel"
               aria-live="polite"
-            ></article>
-            <aside
-              id="project-catalog"
-              class="glass-panel project-catalog"
-              aria-label="Project selector"
-            ></aside>
+            ></div>
           </div>
-
-          <section
-            id="project-depth"
-            class="glass-panel project-depth reveal"
-            aria-live="polite"
-          ></section>
         </section>
 
-        <section id="why-me-contact" class="cta-section reveal">
-          <div class="glass-panel">
-            <p class="section-eyebrow">Partnership</p>
-            <h2 class="section-title">
-              Research should feel like product strategy, not a report.
-            </h2>
+        <section id="skills" class="skills-section reveal">
+          <div class="skills-header">
+            <p class="section-eyebrow">Skills &amp; Expertise</p>
+            <h2 class="section-title">Research systems that scale</h2>
             <p class="section-lede">
-              I help teams move from insight to implementation with clarity.
-              Let’s design the next wave of experiences together.
+              A curated mix of qualitative rigor, quantitative fluency, and
+              facilitation craft to move teams from alignment to action.
             </p>
-            <a class="btn btn-primary" href="mailto:sphoorthy.masa@example.com"
-              >Partner with me</a
-            >
+          </div>
+          <div class="skills-grid">
+            <article class="skill-card">
+              <h3>Research Methodologies</h3>
+              <p>
+                Mixed-method programs spanning discovery, evaluative, and
+                longitudinal studies to surface deep behavioral truths.
+              </p>
+              <ul>
+                <li>User interviews &amp; contextual inquiry</li>
+                <li>Diary studies &amp; remote ethnography</li>
+                <li>Quantitative surveys &amp; segmentation</li>
+                <li>Usability testing &amp; rapid validation</li>
+              </ul>
+            </article>
+            <article class="skill-card">
+              <h3>Tools &amp; Platforms</h3>
+              <p>
+                A flexible toolkit to orchestrate research operations, manage
+                insights, and collaborate across product, design, and data.
+              </p>
+              <ul>
+                <li>UserZoom, UserTesting, Lookback</li>
+                <li>Qualtrics, SurveyMonkey, Airtable</li>
+                <li>Figma, FigJam, Miro, Dovetail</li>
+                <li>Amplitude, GA, Quantum Metric</li>
+              </ul>
+            </article>
+            <article class="skill-card">
+              <h3>Strategic Enablement</h3>
+              <p>
+                Translating insight into direction by facilitating alignment
+                and ensuring research ladders to measurable outcomes.
+              </p>
+              <ul>
+                <li>Vision framing &amp; opportunity mapping</li>
+                <li>Experiment design &amp; KPI modeling</li>
+                <li>Service blueprinting &amp; journey orchestration</li>
+                <li>Executive storytelling &amp; workshops</li>
+              </ul>
+            </article>
           </div>
         </section>
 
@@ -1331,6 +1123,46 @@
             class="testimonial-track"
             aria-live="polite"
           ></div>
+        </section>
+
+        <section id="contact" class="contact-section reveal">
+          <div class="contact-panel glass-panel">
+            <p class="section-eyebrow">Let&rsquo;s build together</p>
+            <h2 class="section-title">Bring research into the spotlight</h2>
+            <p class="section-lede">
+              If you&rsquo;re assembling a team where research shapes strategy,
+              let&rsquo;s connect. Explore the resources below or reach out
+              directly.
+            </p>
+            <div class="contact-grid">
+              <a
+                class="contact-card"
+                href="#contact"
+                aria-label="Resume placeholder"
+              >
+                <span>Resume</span>
+                <p>Download the latest case-study reel and CV.</p>
+              </a>
+              <a
+                class="contact-card"
+                href="mailto:sphoorthy.masa@example.com"
+                aria-label="Email Sphoorthy"
+              >
+                <span>Email</span>
+                <p>Start a conversation about your research roadmap.</p>
+              </a>
+              <a
+                class="contact-card"
+                href="https://www.linkedin.com"
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label="LinkedIn placeholder"
+              >
+                <span>LinkedIn</span>
+                <p>Connect for thought leadership and speaking engagements.</p>
+              </a>
+            </div>
+          </div>
         </section>
       </main>
 

--- a/projects.js
+++ b/projects.js
@@ -7,186 +7,297 @@
     return lastSlash >= 0 ? pathname.slice(0, lastSlash + 1) : "/";
   })();
 
-  const prefersReducedMotion = window.matchMedia(
-    "(prefers-reduced-motion: reduce)",
-  ).matches;
-
   const projects = [
     {
       id: "guide",
       title: "Reinventing the TV Guide",
-      industry: "Streaming · Media",
       summary:
-        "Unified Sling TV and DISH TV discovery into one adaptive experience using multi-surface research.",
-      outcome: "$7.46M annualized upside projected",
-      heroImage: "public/images/guide/guide-03.png",
-      heroAlt: "Unified TV guide concept across multiple devices",
-      metrics: [
-        { value: "~$7.46M", label: "Estimated annual value impact" },
-        { value: "90%", label: "Target task success" },
-        { value: "-12%", label: "CX complaints" },
-      ],
-      focus: [
-        "Unified discovery for Sling & DISH households",
-        "Personalization powered by behavioral telemetry",
-        "Accessibility-ready motion & density system",
-      ],
-      story: [
-        {
-          icon: "🧭",
-          title: "Opportunity framing",
-          copy: "Mapped the end-to-end service blueprint to expose cross-platform friction and align executives.",
-        },
-        {
-          icon: "🧪",
-          title: "Evidence mix",
-          copy: "Diary studies, 18 deep interviews, and 2M session analytics to triangulate everyday behaviors.",
-        },
-        {
-          icon: "🚀",
-          title: "Strategic outcome",
-          copy: "Delivered a phased rollout playbook with KPI ladders and accessibility guardrails.",
-        },
-      ],
-      gallery: [],
-      galleryManifest: true,
-      tagline:
-        "Designing a unified discovery experience for Sling & DISH households.",
+        "Unified Sling TV and DISH discovery into one adaptive experience using multi-surface research.",
+      background:
+        "A strategic research initiative to unify Sling TV and DISH TV guide experiences and turn friction into engagement.",
+      outcome: "~$7.46M estimated annual impact",
+      tileImage: "public/images/guide/guide-03.png",
+      tileImageAlt: "Unified TV guide concept across multiple devices",
       content: {
         metrics: [
-          {
-            value: "~$7.46M",
-            label: "Estimated Annual Value Impact",
-          },
-          { value: "90%", label: "Target Task Success Rate" },
-          { value: "12%", label: "Reduction in CX Complaints" },
+          { value: "~$7.46M", label: "Estimated annual value impact" },
+          { value: "90%", label: "Target task success rate" },
+          { value: "-12%", label: "CX complaints" },
         ],
-        overview: `<div class="text-left space-y-6"><div><h5 class="font-bold text-gray-800 text-lg">Background</h5><p class="text-gray-700 mt-1">The guide sits at the heart of content discovery, but had evolved in parallel across Sling TV and Dish TV, creating fragmented experiences.</p></div><div><h5 class="font-bold text-gray-800 text-lg">The Challenge</h5><p class="text-gray-700 mt-1">How can we unify the guide experience to enhance usability and personalization without alienating loyal users on two very different platforms?</p></div><div><h5 class="font-bold text-gray-800 text-lg">Key Objectives</h5><ul class="list-disc list-inside pl-4 space-y-2 mt-2 text-gray-700"><li>Identify user frustrations and unmet needs across both platforms.</li><li>Uncover shared pain points to guide a unified design strategy.</li><li>Deliver actionable recommendations that balance user needs and business goals.</li></ul></div></div>`,
-        methodology: `<h4>Research Process & Tools</h4><div class="methodology-container mt-6"> <div class="methodology-item"> <h5 style="color:var(--accent-pink-dark);">1. Discovery & Planning</h5> <p>Stakeholder interviews, data analysis, and defining project scope.</p> <div class="mt-4 flex flex-wrap gap-2"><span class="tag-badge">UserZoom</span><span class="tag-badge">Google Analytics</span><span class="tag-badge">JIRA</span></div> </div> <div class="methodology-item"> <h5 style="color:var(--accent-pink-dark);">2. Generative Research</h5> <p>In-depth user interviews to uncover behaviors and motivations.</p> <div class="mt-4 flex flex-wrap gap-2"><span class="tag-badge">User Interviews</span><span class="tag-badge">Lookback</span><span class="tag-badge">Google Meet</span></div> </div> <div class="methodology-item"> <h5 style="color:var(--accent-pink-dark);">3. Synthesis & Ideation</h5> <p>Mapping insights and collaborating with design and product teams.</p> <div class="mt-4 flex flex-wrap gap-2"><span class="tag-badge">Miro</span><span class="tag-badge">Figma</span></div> </div> <div class="methodology-item"> <h5 style="color:var(--accent-pink-dark);">4. Validation & Delivery</h5> <p>Usability testing and handoff to engineering teams.</p> <div class="mt-4 flex flex-wrap gap-2"><span class="tag-badge">UserTesting.com</span><span class="tag-badge">Figma Prototypes</span><span class="tag-badge">Confluence</span></div> </div> </div>`,
-        analysis: `<h4>Target Audience & Segments</h4><div class="flex flex-col md:flex-row gap-4 mt-4 text-left"><div class="flex-1 p-4 bg-black/5 rounded-lg border border-black/5"><h5 class="font-bold text-gray-800">DISH TV Subscribers (65+)</h5><p class="text-sm text-gray-600">Tolerate outdated UI but struggle with hidden features; often have accessibility needs.</p></div><div class="flex-1 p-4 bg-black/5 rounded-lg border border-black/5"><h5 class="font-bold text-gray-800">Sling TV Subscribers (~35)</h5><p class="text-sm text-gray-600">Tech-savvy, expect fast, intuitive interfaces and quick content access.</p></div></div><h4 class="mt-8">Key Quantitative Insights</h4><div class="grid md:grid-cols-2 gap-4 mt-4 text-gray-700 text-left"><div class="insight-card"><h5>1. High Engagement, Low Conversion</h5><ul class="text-sm list-disc list-inside my-2 space-y-1"><li><b>Sling TV:</b> 79% engagement → 56% playback</li><li><b>DISH TV:</b> 86% engagement → 48% playback</li></ul><p class="text-sm" style="color: var(--accent-pink-dark);">🔍 Insight: Strong adoption, but poor discoverability leads to drop-offs.</p></div><div class="insight-card"><h5>2. Underutilized Features</h5><ul class="text-sm list-disc list-inside my-2 space-y-1"><li>73% of sessions used the default "ALL" filter.</li><li>"Favorites" users had a 64% playback rate vs. 55% for others.</li></ul><p class="text-sm" style="color: var(--accent-pink-dark);">🔍 Insight: Personalization improves engagement but is underused.</p></div><div class="insight-card"><h5>3. High Drop-Offs in Short Sessions</h5><ul class="text-sm list-disc list-inside my-2 space-y-1"><li>44% of Sling guide sessions ended without playback.</li><li>Most of these non-playback sessions lasted &lt;20 seconds.</li></ul><p class="text-sm" style="color: var(--accent-pink-dark);">🔍 Insight: Users abandon quickly, suggesting poor content surfacing.</p></div><div class="insight-card"><h5>4. Habitual Navigation (DISH)</h5><ul class="text-sm list-disc list-inside my-2 space-y-1"><li>46% of users navigated vertically by habit.</li><li>Only 8% used faster horizontal navigation by time.</li></ul><p class="text-sm" style="color: var(--accent-pink-dark);">🔍 Insight: Users may not be aware of more efficient navigation options.</p></div></div>`,
-        results: `<p class="text-center text-lg">The research insights directly led to iterative design improvements, validating each solution through rigorous testing to ensure it met user needs and business goals.</p><h4 class="mt-8">Financial Impact</h4><div class="grid md:grid-cols-2 lg:grid-cols-4 gap-4 mt-4 text-gray-700"><div class="stat-card"><div class="stat-number">~$5.83M</div><div class="stat-description">from Increased Retention</div></div><div class="stat-card"><div class="stat-number">~$1.94M</div><div class="stat-description">from Feature Upsells</div></div><div class="stat-card"><div class="stat-number">~$193k</div><div class="stat-description">from Ad Revenue</div></div><div class="stat-card"><div class="stat-number">~$63k</div><div class="stat-description">from Ops Savings</div></div></div>`,
-        media: `<h4>Media Assets</h4><div id="guide-media-grid" class="grid grid-cols-1 sm:grid-cols-2 gap-4 mt-4"></div><p class="mt-4 text-sm text-center text-gray-500">Key visuals, user flows, and prototypes from the project.</p>`,
+        overview: `
+          <div class="detail-copy">
+            <div>
+              <h4>Background</h4>
+              <p>The guide sits at the heart of content discovery but had evolved in parallel across Sling TV and DISH TV, creating fragmented experiences.</p>
+            </div>
+            <div>
+              <h4>The challenge</h4>
+              <p>Unify the guide experience to enhance usability and personalization without alienating loyal users on two very different platforms.</p>
+            </div>
+            <div>
+              <h4>Objectives</h4>
+              <ul>
+                <li>Identify user frustrations and unmet needs across platforms.</li>
+                <li>Uncover shared pain points to guide a unified design strategy.</li>
+                <li>Deliver actionable recommendations that balance user and business goals.</li>
+              </ul>
+            </div>
+          </div>
+        `,
+        methodology: `
+          <div class="detail-copy">
+            <div>
+              <h4>Discovery &amp; planning</h4>
+              <p>Partnered with product and ops leads to frame the opportunity, synthesize data, and establish decision criteria.</p>
+              <p><strong>Tools:</strong> UserZoom, Google Analytics, JIRA</p>
+            </div>
+            <div>
+              <h4>Generative research</h4>
+              <p>In-depth interviews revealed how households navigate content, why favorites lists stall, and what trust signals are missing.</p>
+              <p><strong>Tools:</strong> Lookback, remote moderated sessions</p>
+            </div>
+            <div>
+              <h4>Synthesis &amp; ideation</h4>
+              <p>Mapped journeys and service blueprints to expose systemic friction, co-creating with design and engineering.</p>
+              <p><strong>Tools:</strong> FigJam, Figma</p>
+            </div>
+            <div>
+              <h4>Validation &amp; delivery</h4>
+              <p>Iterative usability testing and launch playbooks ensured accessibility and operational readiness.</p>
+              <p><strong>Tools:</strong> UserTesting, Confluence</p>
+            </div>
+          </div>
+        `,
+        analysis: `
+          <div class="detail-copy">
+            <div>
+              <h4>Audience segments</h4>
+              <p><strong>DISH subscribers:</strong> rely on legacy navigation, need clarity and accessibility. <strong>Sling subscribers:</strong> expect speed, personalization, and cross-device parity.</p>
+            </div>
+            <div>
+              <h4>Quantitative signals</h4>
+              <ul>
+                <li>High engagement but lower playback (79% engagement → 56% playback on Sling).</li>
+                <li>Personalization features were underutilized despite clear retention gains.</li>
+                <li>44% of Sling guide sessions ended within 20 seconds without playback.</li>
+                <li>Navigation habits masked faster, time-based browsing patterns.</li>
+              </ul>
+            </div>
+          </div>
+        `,
+        results: `
+          <div class="detail-copy">
+            <p>Evidence-backed recommendations delivered measurable value across retention, upsell, and ad revenue channels.</p>
+            <ul>
+              <li><strong>$5.83M</strong> projected from retention uplift.</li>
+              <li><strong>$1.94M</strong> from feature upsells tied to personalization.</li>
+              <li><strong>$193K</strong> in incremental ad revenue.</li>
+              <li><strong>$63K</strong> in operational savings through workflow clarity.</li>
+            </ul>
+          </div>
+        `,
+        media: {
+          featured: {
+            src: "public/images/guide/guide-05.png",
+            alt: "Channel grid concept with tuned information density",
+          },
+          carousel: [
+            {
+              src: "public/images/guide/guide-07.png",
+              alt: "Transition storyboard for the guide redesign",
+            },
+            {
+              src: "public/images/guide/gr-01.png",
+              alt: "Discovery synthesis mural highlighting pain points",
+            },
+            {
+              src: "public/images/guide/gr-02.png",
+              alt: "Persona snapshots aligning Sling and DISH audiences",
+            },
+            {
+              src: "public/images/guide/gr-03.png",
+              alt: "Service blueprint mapping current and future states",
+            },
+          ],
+          caption: "Key visuals, flows, and prototypes that shaped the unified guide vision.",
+        },
       },
     },
     {
       id: "gundersen",
       title: "Gundersen Health Virtual Care OS",
-      industry: "Healthcare · SaaS",
       summary:
         "Reimagined intake and triage flows for clinicians and patients inside a unified virtual care operating system.",
-      outcome: "32% faster intake & triage across clinics",
+      background:
+        "Streamlining prescription refills by empowering patients and reducing manual work for pharmacy staff.",
+      outcome: "12,334+ active app users within 6 months",
       heroImage:
         "https://images.unsplash.com/photo-1580281658629-26036f899014?auto=format&fit=crop&w=1600&q=80",
-      heroAlt: "Clinician using a digital health dashboard",
-      metrics: [
-        { value: "32%", label: "Faster intake" },
-        { value: "4.7★", label: "Clinician satisfaction" },
-        { value: "3 mos", label: "Launch acceleration" },
-      ],
-      focus: [
-        "Cross-clinic workflow mapping",
-        "Multi-role dashboard prototyping",
-        "HIPAA-compliant experimentation",
-      ],
-      story: [
-        {
-          icon: "🩺",
-          title: "Field immersion",
-          copy: "Shadowed 6 clinics and captured 40+ hours of intake footage to surface friction and opportunities.",
+      heroAlt: "Clinician reviewing a virtual care dashboard",
+      content: {
+        metrics: [
+          { value: "12,334+", label: "Active app users" },
+          { value: "36%", label: "Refill volume via app" },
+          { value: "$702K+", label: "Annual labor savings" },
+        ],
+        overview: `
+          <div class="detail-copy">
+            <div>
+              <h4>Background</h4>
+              <p>The mobile refill app aimed to reduce repetitive pharmacy work and enable patients to manage medications independently.</p>
+            </div>
+            <div>
+              <h4>Research goals</h4>
+              <ul>
+                <li>Drive awareness and adoption across clinics.</li>
+                <li>Shift 25% of monthly refills into the app experience.</li>
+                <li>Automate refill reminders and status updates at scale.</li>
+                <li>Reduce inbound call volume and manual outreach.</li>
+              </ul>
+            </div>
+          </div>
+        `,
+        methodology: `
+          <div class="detail-copy">
+            <div>
+              <h4>Workflow &amp; stakeholder analysis</h4>
+              <p>Shadowed pharmacists, RNs, and MAs to map the manual refill process and quantify hidden labor costs.</p>
+            </div>
+            <div>
+              <h4>Usability &amp; heuristic evaluation</h4>
+              <p>Evaluated the existing app with patients and staff to surface friction, accessibility gaps, and trust barriers.</p>
+            </div>
+            <div>
+              <h4>Discovery synthesis</h4>
+              <p>Reframed the problem around awareness and education, pairing messaging experiments with product refinements.</p>
+            </div>
+          </div>
+        `,
+        analysis: `
+          <div class="detail-copy">
+            <ul>
+              <li><strong>Minimalist UI delivered 95% task success</strong> but lacked emotional engagement.</li>
+              <li><strong>Awareness, not usability, blocked adoption</strong>—most patients didn’t know the app existed.</li>
+              <li><strong>Clinicians sought automation</strong> to reduce outbound calls and status updates.</li>
+            </ul>
+          </div>
+        `,
+        results: `
+          <div class="detail-copy">
+            <p>Marketing pilots plus in-clinic coaching exceeded every launch metric within six months.</p>
+            <ul>
+              <li><strong>12,334</strong> active users vs. the 10,000 target.</li>
+              <li><strong>16,476</strong> monthly refills vs. the 11,250 goal.</li>
+              <li><strong>$702K+</strong> in recovered labor time by reducing manual calls.</li>
+            </ul>
+          </div>
+        `,
+        media: {
+          featured: {
+            src: "https://images.unsplash.com/photo-1587614382346-4ec892f9aca3?auto=format&fit=crop&w=1600&q=80",
+            alt: "Telehealth dashboard interface concept",
+          },
+          carousel: [
+            {
+              src: "https://images.unsplash.com/photo-1580894894513-d75ec1c5c5a1?auto=format&fit=crop&w=1600&q=80",
+              alt: "Patient testing the simplified refill journey",
+            },
+            {
+              src: "https://images.unsplash.com/photo-1581090700227-1e37b190418e?auto=format&fit=crop&w=1600&q=80",
+              alt: "Co-creation workshop with clinical stakeholders",
+            },
+          ],
+          caption: "Pilot campaigns, usability labs, and co-creation sessions that drove adoption.",
         },
-        {
-          icon: "🧬",
-          title: "Quantified impact",
-          copy: "Mapped EMR logs to pain points and prioritized backlog based on throughput and readmission risk.",
-        },
-        {
-          icon: "🤝",
-          title: "Operational adoption",
-          copy: "Coached nurse champions and product leads on rolling out evidence-backed workflow changes.",
-        },
-      ],
-      gallery: [
-        {
-          src: "https://images.unsplash.com/photo-1587614382346-4ec892f9aca3?auto=format&fit=crop&w=1600&q=80",
-          alt: "Telehealth dashboard interface",
-          caption:
-            "Concept dashboard enabling clinicians to triage multi-channel visits.",
-        },
-        {
-          src: "https://images.unsplash.com/photo-1580894894513-d75ec1c5c5a1?auto=format&fit=crop&w=1600&q=80",
-          alt: "Patient using a tablet at home",
-          caption:
-            "Home-based participant testing the simplified intake journey.",
-        },
-        {
-          src: "https://images.unsplash.com/photo-1581090700227-1e37b190418e?auto=format&fit=crop&w=1600&q=80",
-          alt: "Research team co-creating a journey map",
-          caption:
-            "Co-creation lab aligning clinical and product stakeholders on future workflows.",
-        },
-      ],
-      tagline:
-        "Accelerating virtual care with evidence-backed workflow orchestration.",
+      },
     },
     {
       id: "live-rooms",
-      title: "Live Rooms Interactive Watch Parties",
-      industry: "Streaming · Social",
+      title: "Validating Live Rooms",
       summary:
         "Launched a co-watching and commerce layer that extends live broadcasts into interactive communities.",
-      outcome: "18% lift in session length across pilot cohorts",
+      background:
+        "Validating a social TV concept by understanding how people want to engage during live content.",
+      outcome: "Guided go/no-go decision",
       heroImage:
         "https://images.unsplash.com/photo-1511512578047-dfb367046420?auto=format&fit=crop&w=1600&q=80",
-      heroAlt: "Friends enjoying a streaming session with neon lighting",
-      metrics: [
-        { value: "+18%", label: "Session length" },
-        { value: "94%", label: "Feature adoption" },
-        { value: "6 wks", label: "Insight to beta" },
-      ],
-      focus: [
-        "Real-time engagement loops",
-        "Commerce & conversion experiments",
-        "Accessibility for shared experiences",
-      ],
-      story: [
-        {
-          icon: "🎙️",
-          title: "Audience listening",
-          copy: "Ran rolling diary studies with superfans to translate rituals into product behaviors.",
+      heroAlt: "Friends enjoying an illuminated streaming session",
+      content: {
+        metrics: [
+          { value: "87%", label: "Liked interactive features" },
+          { value: "76%", label: "Preferred second-screen" },
+          { value: "56%", label: "Engaged with emoji reactions" },
+          { value: "41%", label: "Enjoyed live quizzes" },
+        ],
+        overview: `
+          <div class="detail-copy">
+            <div>
+              <h4>Background</h4>
+              <p>Live Rooms explored how social chat, reactions, and interactive moments could elevate live TV viewing across genres.</p>
+            </div>
+            <div>
+              <h4>Research goals</h4>
+              <ul>
+                <li>Gauge desirability of interactive layers across sports and entertainment.</li>
+                <li>Understand how social features impact attention and enjoyment.</li>
+                <li>Ensure experimentation doesn’t disrupt core viewing.</li>
+              </ul>
+            </div>
+          </div>
+        `,
+        methodology: `
+          <div class="detail-copy">
+            <div>
+              <h4>Concept tests</h4>
+              <p>Eight in-depth sessions balanced experienced streamers and newcomers to probe baseline expectations.</p>
+            </div>
+            <div>
+              <h4>Live pilots</h4>
+              <p>Ran NBA and reality TV watch parties with 100+ participants, capturing telemetry and survey feedback.</p>
+            </div>
+            <div>
+              <h4>Signal instrumentation</h4>
+              <p>Tracked engagement loops, moderation needs, and conversion moments to inform roadmap bets.</p>
+            </div>
+          </div>
+        `,
+        analysis: `
+          <div class="detail-copy">
+            <ul>
+              <li><strong>Control is essential:</strong> 87% wanted the ability to toggle chat and reactions.</li>
+              <li><strong>Second-screen behavior:</strong> 76% preferred interacting on mobile while watching on TV.</li>
+              <li><strong>Feature fit varies by genre:</strong> Sports fans embraced fast chat; reality TV fans favored polls and quizzes.</li>
+            </ul>
+          </div>
+        `,
+        results: `
+          <div class="detail-copy">
+            <p>Engagement lifts across pilots informed a confident recommendation to proceed with phased investment.</p>
+            <ul>
+              <li><strong>3.1 hrs</strong> average viewing time during Jersey Shore Family Vacation pilots.</li>
+              <li><strong>94%</strong> feature adoption during BET Awards experiments.</li>
+              <li><strong>18%</strong> lift in session length across all cohorts.</li>
+            </ul>
+          </div>
+        `,
+        media: {
+          featured: {
+            src: "https://images.unsplash.com/photo-1525182008055-f88b95ff7980?auto=format&fit=crop&w=1600&q=80",
+            alt: "Prototype testing synchronized playback and chat",
+          },
+          carousel: [
+            {
+              src: "https://images.unsplash.com/photo-1525182008051-d4d6360c81e5?auto=format&fit=crop&w=1600&q=80",
+              alt: "Interactive live room interface exploration",
+            },
+            {
+              src: "https://images.unsplash.com/photo-1512427691650-1e0c0a1db8f1?auto=format&fit=crop&w=1600&q=80",
+              alt: "Researcher facilitating a live viewing workshop",
+            },
+          ],
+          caption: "Concept explorations, live pilots, and team workshops guiding the go/no-go decision.",
         },
-        {
-          icon: "📊",
-          title: "Signal instrumentation",
-          copy: "Designed telemetry to measure co-watching retention, sentiment, and conversion moments.",
-        },
-        {
-          icon: "✨",
-          title: "Launch craft",
-          copy: "Partnered with design to define choreography, moderation tools, and revenue-ready pathways.",
-        },
-      ],
-      gallery: [
-        {
-          src: "https://images.unsplash.com/photo-1525182008055-f88b95ff7980?auto=format&fit=crop&w=1600&q=80",
-          alt: "People streaming together with devices",
-          caption:
-            "Prototype testing of synchronized playback and chat overlays.",
-        },
-        {
-          src: "https://images.unsplash.com/photo-1525182008051-d4d6360c81e5?auto=format&fit=crop&w=1600&q=80",
-          alt: "Interactive live room interface exploration",
-          caption:
-            "Hi-fi interface exploration for layered interactive controls.",
-        },
-        {
-          src: "https://images.unsplash.com/photo-1512427691650-1e0c0a1db8f1?auto=format&fit=crop&w=1600&q=80",
-          alt: "UX researcher facilitating a workshop",
-          caption:
-            "Cross-functional workshop mapping monetization and moderation scenarios.",
-        },
-      ],
-      tagline:
-        "Transforming passive viewing into vibrant, revenue-ready communities.",
+      },
     },
   ];
 
@@ -230,9 +341,7 @@
   ];
 
   const state = {
-    activeId: projects[0]?.id || null,
-    carouselController: null,
-    guideMediaSlides: null,
+    activeId: projects[0]?.id ?? null,
   };
 
   function asset(path) {
@@ -245,7 +354,7 @@
   }
 
   function escapeHtml(value) {
-    return String(value || "")
+    return String(value ?? "")
       .replace(/&/g, "&amp;")
       .replace(/</g, "&lt;")
       .replace(/>/g, "&gt;")
@@ -269,7 +378,7 @@
       (entries) => {
         entries.forEach((entry) => {
           if (entry.isIntersecting) {
-            entry.target.classList.add("is-visible");
+            entry.target.classList.add("visible", "is-visible");
             observer.unobserve(entry.target);
           }
         });
@@ -279,549 +388,186 @@
     elements.forEach((el) => observer.observe(el));
   }
 
-  function renderProjects() {
-    const showcase = document.getElementById("project-showcase");
-    const catalog = document.getElementById("project-catalog");
-    const depth = document.getElementById("project-depth");
-    if (!showcase || !catalog || !depth || !projects.length) return;
-
-    const active =
-      projects.find((project) => project.id === state.activeId) || projects[0];
-    state.activeId = active.id;
-
-    if (state.carouselController?.stop) {
-      state.carouselController.stop();
-      state.carouselController = null;
-    }
-
-    showcase.innerHTML = createShowcaseMarkup(active);
-    catalog.innerHTML = projects
-      .map((project) => createCatalogMarkup(project, project.id === active.id))
-      .join("");
-    depth.innerHTML = createDepthMarkup(active);
-    activateDetailTabs(depth);
-    hydrateMediaTab(active);
-
-    if (active.gallery && active.gallery.length) {
-      mountCarousel(active.id);
-    }
-  }
-
-  function createShowcaseMarkup(project) {
-    const heroSrc = asset(
-      project.heroImage ||
-        project.gallery?.[0]?.src ||
-        "public/images/guide/guide-01.png",
-    );
-    const metricsHtml = (project.metrics || [])
-      .map(
-        (metric) => `
-        <div class="metric-tile">
-          <div class="metric-value">${escapeHtml(metric.value)}</div>
-          <div class="metric-label">${escapeHtml(metric.label)}</div>
-        </div>
-      `,
-      )
-      .join("");
-
-    return `
-      <div>
-        <p class="section-eyebrow">Featured case study</p>
-        <h3 class="project-showcase__title">${escapeHtml(project.title)}</h3>
-        <p class="project-showcase__summary">${escapeHtml(project.summary)}</p>
-        <p class="project-showcase__outcome">${escapeHtml(project.outcome)}</p>
-      </div>
-      <div class="project-showcase__visual">
-        <img src="${heroSrc}" alt="${escapeHtml(
-          project.heroAlt || project.title,
-        )}" loading="lazy" />
-      </div>
-      <div class="metrics-grid">${metricsHtml}</div>
-      <a class="project-showcase__cta" href="#project-depth">
-        See how it came to life
-        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
-          <path d="M5 12h14" />
-          <path d="M13 6l6 6-6 6" />
-        </svg>
-      </a>
-    `;
-  }
-
-  function createCatalogMarkup(project, isActive) {
-    return `
-      <button type="button" class="catalog-card${isActive ? " active" : ""}" data-project="${project.id}" aria-pressed="${isActive}">
-        <span class="catalog-card__eyebrow">${escapeHtml(
-          project.industry || "Case Study",
-        )}</span>
-        <h4>${escapeHtml(project.title)}</h4>
-        <p>${escapeHtml(project.tagline || project.summary)}</p>
-        <span class="catalog-card__cta">${isActive ? "Selected" : "View project"}</span>
-      </button>
-    `;
-  }
-
-  function createDepthMarkup(project) {
-    const detailMarkup = createDetailPanel(project);
-
-    const focusHtml = (project.focus || [])
-      .map((item) => `<span>${escapeHtml(item)}</span>`)
-      .join("");
-
-    const focusSection = focusHtml
-      ? `
-      <div>
-        <p class="section-eyebrow">Focus areas</p>
-        <div class="focus-chips">${focusHtml}</div>
-      </div>
-    `
-      : "";
-
-    const carouselMarkup = createCarouselMarkup(project);
-
-    const insightsHtml = (project.story || [])
-      .map(
-        (item) => `
-          <div class="insight-card">
-            <strong><span class="insight-card__icon">${escapeHtml(
-              item.icon || "✦",
-            )}</span>${escapeHtml(item.title)}</strong>
-            <p>${escapeHtml(item.copy)}</p>
-          </div>
-        `,
-      )
-      .join("");
-
-    const insightsSection = insightsHtml
-      ? `
-      <div>
-        <p class="section-eyebrow">Strategic takeaways</p>
-        <div class="insight-grid">${insightsHtml}</div>
-      </div>
-    `
-      : "";
-
-    return [detailMarkup, focusSection, carouselMarkup, insightsSection]
-      .filter(Boolean)
-      .join("");
-  }
-
-  function createDetailPanel(project) {
-    const content = project.content;
-    if (!content) return "";
-
-    const metrics = Array.isArray(content.metrics) ? content.metrics : [];
-    const metricMarkup = metrics
-      .map(
-        (metric) => `
-          <div class="detail-metric">
-            <div class="detail-metric__value">${escapeHtml(metric.value)}</div>
-            <div class="detail-metric__label">${escapeHtml(metric.label)}</div>
-          </div>
-        `,
-      )
-      .join("");
-
-    const tabOrder = ["overview", "methodology", "analysis", "results", "media"];
-    const tabs = tabOrder.filter((key) => content[key]);
-    if (!tabs.length && !metricMarkup) {
-      return "";
-    }
-
-    const buttons = tabs
-      .map((tab, index) => {
-        const label = tab.charAt(0).toUpperCase() + tab.slice(1);
-        const panelId = `${project.id}-${tab}-panel`;
-        const tabId = `${project.id}-${tab}-tab`;
+  function renderProjectTiles() {
+    const container = document.getElementById("project-tiles");
+    if (!container || !projects.length) return;
+    container.innerHTML = projects
+      .map((project) => {
+        const isActive = project.id === state.activeId;
+        const imageSrc = asset(
+          project.tileImage ||
+            project.heroImage ||
+            project.content?.media?.featured?.src ||
+            "",
+        );
+        const imageAlt = project.tileImageAlt || project.heroAlt || project.title;
         return `
-          <button
-            type="button"
-            class="detail-tab${index === 0 ? " is-active" : ""}"
-            role="tab"
-            id="${tabId}"
-            aria-selected="${index === 0 ? "true" : "false"}"
-            aria-controls="${panelId}"
-            tabindex="${index === 0 ? "0" : "-1"}"
-            data-tab="${tab}"
-          >${label}</button>
+          <button type="button" class="project-tile${
+            isActive ? " active" : ""
+          }" data-project-id="${project.id}">
+            <h3>${escapeHtml(project.title)}</h3>
+            <p>${escapeHtml(project.background)}</p>
+            <p class="project-outcome"><strong>Results</strong> ${escapeHtml(
+              project.outcome,
+            )}</p>
+            ${
+              imageSrc
+                ? `<figure><img src="${imageSrc}" alt="${escapeHtml(
+                    imageAlt,
+                  )}" loading="lazy" /></figure>`
+                : ""
+            }
+          </button>
         `;
       })
       .join("");
-
-    const panels = tabs
-      .map((tab, index) => {
-        const panelId = `${project.id}-${tab}-panel`;
-        const tabId = `${project.id}-${tab}-tab`;
-        const hiddenAttr = index === 0 ? "" : " hidden";
-        return `
-          <div
-            class="detail-pane${index === 0 ? " is-active" : ""}"
-            role="tabpanel"
-            id="${panelId}"
-            aria-labelledby="${tabId}"
-            data-tab-panel="${tab}"${hiddenAttr}
-          >${content[tab]}</div>
-        `;
-      })
-      .join("");
-
-    return `
-      <section class="detail-panel glass-panel" data-detail-tabs>
-        ${metricMarkup ? `<div class="detail-metrics">${metricMarkup}</div>` : ""}
-        ${
-          buttons
-            ? `<div class="detail-tabs" role="tablist" aria-label="${escapeHtml(
-                project.title,
-              )} details">${buttons}</div>`
-            : ""
-        }
-        <div class="detail-content">${panels}</div>
-      </section>
-    `;
   }
 
-  function activateDetailTabs(root) {
-    const container = root.querySelector("[data-detail-tabs]");
+  function renderProjectDetail() {
+    const container = document.getElementById("project-detail");
     if (!container) return;
-
-    const buttons = Array.from(container.querySelectorAll("[data-tab]"));
-    const panels = Array.from(container.querySelectorAll("[data-tab-panel]"));
-    if (!buttons.length || !panels.length) return;
-
-    const setActive = (tab) => {
-      buttons.forEach((button) => {
-        const isActive = button.getAttribute("data-tab") === tab;
-        button.classList.toggle("is-active", isActive);
-        button.setAttribute("aria-selected", isActive ? "true" : "false");
-        button.setAttribute("tabindex", isActive ? "0" : "-1");
-      });
-
-      panels.forEach((panel) => {
-        const isActive = panel.getAttribute("data-tab-panel") === tab;
-        panel.classList.toggle("is-active", isActive);
-        if (isActive) {
-          panel.removeAttribute("hidden");
-        } else {
-          panel.setAttribute("hidden", "true");
-        }
-      });
-    };
-
-    container.addEventListener("click", (event) => {
-      const button = event.target.closest("[data-tab]");
-      if (!button) return;
-      event.preventDefault();
-      setActive(button.getAttribute("data-tab"));
-    });
-
-    container.addEventListener("keydown", (event) => {
-      if (!["ArrowLeft", "ArrowRight", "Home", "End"].includes(event.key)) {
-        return;
-      }
-      const current = document.activeElement.closest("[data-tab]");
-      if (!current) return;
-      event.preventDefault();
-      const currentIndex = buttons.indexOf(current);
-      if (currentIndex === -1) return;
-      let nextIndex = currentIndex;
-      if (event.key === "ArrowRight") {
-        nextIndex = (currentIndex + 1) % buttons.length;
-      } else if (event.key === "ArrowLeft") {
-        nextIndex = (currentIndex - 1 + buttons.length) % buttons.length;
-      } else if (event.key === "Home") {
-        nextIndex = 0;
-      } else if (event.key === "End") {
-        nextIndex = buttons.length - 1;
-      }
-      const nextButton = buttons[nextIndex];
-      setActive(nextButton.getAttribute("data-tab"));
-      nextButton.focus();
-    });
-  }
-
-  function hydrateMediaTab(project) {
-    if (!project?.content?.media) return;
-    const grid = document.getElementById("guide-media-grid");
-    if (!grid) return;
-
-    const slides =
-      (project.id === "guide" && state.guideMediaSlides?.length
-        ? state.guideMediaSlides
-        : project.gallery) || [];
-
-    if (!slides.length) {
-      grid.innerHTML =
-        '<p class="text-sm text-center text-gray-500">Media coming soon.</p>';
+    const project = projects.find((item) => item.id === state.activeId);
+    if (!project) {
+      container.innerHTML = "";
       return;
     }
 
-    const markup = slides
-      .map((slide) => {
-        const caption = slide.caption
-          ? `<figcaption>${escapeHtml(slide.caption)}</figcaption>`
-          : "";
+    const metricsMarkup = (project.content?.metrics || [])
+      .map(
+        (metric) => `
+          <div class="metric-card">
+            <div class="metric-card-value">${escapeHtml(metric.value)}</div>
+            <div class="metric-card-label">${escapeHtml(metric.label)}</div>
+          </div>
+        `,
+      )
+      .join("");
+
+    const sections = [
+      { key: "overview", label: "Overview" },
+      { key: "methodology", label: "Methodology" },
+      { key: "analysis", label: "Analysis" },
+      { key: "results", label: "Results" },
+      { key: "media", label: "Media" },
+    ].filter((section) => project.content?.[section.key]);
+
+    const tabButtons = sections
+      .map(
+        (section, index) => `
+          <button type="button" data-tab="${section.key}"${
+          index === 0 ? " class=\"active\"" : ""
+        }>${section.label}</button>
+        `,
+      )
+      .join("");
+
+    const tabPanels = sections
+      .map((section, index) => {
+        const html =
+          section.key === "media"
+            ? renderMediaSection(project.content?.media)
+            : project.content?.[section.key];
         return `
-          <figure class="media-grid__item">
-            <img src="${asset(slide.src)}" alt="${escapeHtml(
-              slide.alt || project.title,
-            )}" loading="lazy" />
-            ${caption}
-          </figure>
+          <div class="tab-content${index === 0 ? " active" : ""}" data-tab-panel="${
+            section.key
+          }">${html ?? ""}</div>
         `;
       })
       .join("");
 
-    grid.innerHTML = markup;
+    container.innerHTML = `
+      <header>
+        <span class="section-eyebrow">Case study</span>
+        <h3>${escapeHtml(project.title)}</h3>
+        ${project.summary ? `<p>${escapeHtml(project.summary)}</p>` : ""}
+      </header>
+      ${metricsMarkup ? `<div class="detail-metrics">${metricsMarkup}</div>` : ""}
+      ${
+        sections.length
+          ? `<div class="details-tabs">${tabButtons}</div><div class="tab-panels">${tabPanels}</div>`
+          : ""
+      }
+    `;
+
+    initTabInteractions(container);
   }
 
-  function createCarouselMarkup(project) {
-    const slides = project.gallery || [];
-    if (!slides.length) {
-      const placeholder = project.galleryManifest
-        ? '<div class="media-caption">Loading visuals from the research vault…</div>'
-        : '<div class="media-caption">Visual narrative coming soon.</div>';
-      return `
-        <div class="media-carousel" data-project="${project.id}" data-empty="true">
-          <div class="media-carousel__slides">
-            <div class="media-slide is-active" aria-hidden="false">${placeholder}</div>
-          </div>
+  function renderMediaSection(media) {
+    if (!media) {
+      return `<div class="detail-copy"><p>Media assets coming soon.</p></div>`;
+    }
+
+    const featured = media.featured
+      ? `
+        <div class="media-featured">
+          <img src="${asset(media.featured.src)}" alt="${escapeHtml(
+          media.featured.alt || "Project media",
+        )}" loading="lazy" />
+        </div>
+      `
+      : "";
+
+    let carousel = "";
+    if (Array.isArray(media.carousel) && media.carousel.length) {
+      const items = media.carousel
+        .map(
+          (item) => `
+            <div class="media-carousel__item">
+              <img src="${asset(item.src)}" alt="${escapeHtml(
+            item.alt || "Project gallery",
+          )}" loading="lazy" />
+            </div>
+          `,
+        )
+        .join("");
+      carousel = `
+        <div class="media-carousel">
+          <div class="media-carousel__track">${items}${items}</div>
         </div>
       `;
     }
 
-    const slidesHtml = slides
-      .slice(0, 8)
-      .map(
-        (slide, index) => `
-          <figure class="media-slide${index === 0 ? " is-active" : ""}" aria-hidden="${index === 0 ? "false" : "true"}">
-            <img src="${asset(slide.src)}" alt="${escapeHtml(
-              slide.alt || project.title,
-            )}" loading="lazy" />
-            <figcaption class="media-caption">${escapeHtml(
-              slide.caption || "",
-            )}</figcaption>
-          </figure>
-        `,
-      )
-      .join("");
+    const caption = media.caption
+      ? `<p>${escapeHtml(media.caption)}</p>`
+      : "";
 
-    const dotsHtml =
-      slides.length > 1
-        ? `<div class="media-dots">${slides
-            .map(
-              (_, index) => `
-              <button type="button" class="media-dot${
-                index === 0 ? " is-active" : ""
-              }" data-carousel-dot="${index}" aria-label="Go to visual ${
-                index + 1
-              }"></button>
-            `,
-            )
-            .join("")}</div>`
-        : "";
-
-    const controlsHtml =
-      slides.length > 1
-        ? `<div class="media-controls">
-          <button type="button" data-carousel-prev aria-label="Previous visual">‹</button>
-          ${dotsHtml}
-          <button type="button" data-carousel-next aria-label="Next visual">›</button>
-        </div>`
-        : "";
-
-    return `
-      <div class="media-carousel" data-project="${project.id}">
-        <div class="media-carousel__slides">${slidesHtml}</div>
-        ${controlsHtml}
-      </div>
-    `;
+    return `<div class="detail-copy">${featured}${carousel}${caption}</div>`;
   }
 
-  function mountCarousel(projectId) {
-    const container = document.querySelector(
-      `.media-carousel[data-project="${projectId}"]`,
-    );
+  function initTabInteractions(container) {
+    const buttons = Array.from(container.querySelectorAll(".details-tabs button"));
+    const panels = Array.from(container.querySelectorAll(".tab-content"));
+    if (!buttons.length || !panels.length) return;
+
+    const setActive = (tab) => {
+      buttons.forEach((button) => {
+        const isActive = button.dataset.tab === tab;
+        button.classList.toggle("active", isActive);
+      });
+      panels.forEach((panel) => {
+        const isActive = panel.dataset.tabPanel === tab;
+        panel.classList.toggle("active", isActive);
+      });
+    };
+
+    buttons.forEach((button) => {
+      button.addEventListener("click", () => {
+        setActive(button.dataset.tab);
+      });
+    });
+  }
+
+  function mountProjectInteractions() {
+    const container = document.getElementById("project-tiles");
     if (!container) return;
-    const slides = Array.from(container.querySelectorAll(".media-slide"));
-    if (slides.length <= 1) return;
-
-    const dots = Array.from(container.querySelectorAll("[data-carousel-dot]"));
-    const prevBtn = container.querySelector("[data-carousel-prev]");
-    const nextBtn = container.querySelector("[data-carousel-next]");
-    let index = 0;
-    let timerId = null;
-
-    const setActive = (nextIndex) => {
-      index = nextIndex;
-      slides.forEach((slide, idx) => {
-        const isActive = idx === index;
-        slide.classList.toggle("is-active", isActive);
-        slide.setAttribute("aria-hidden", isActive ? "false" : "true");
-      });
-      dots.forEach((dot, idx) =>
-        dot.classList.toggle("is-active", idx === index),
-      );
-    };
-
-    const next = () => setActive((index + 1) % slides.length);
-    const prev = () => setActive((index - 1 + slides.length) % slides.length);
-
-    const stopAuto = () => {
-      if (timerId) {
-        window.clearInterval(timerId);
-        timerId = null;
-      }
-    };
-
-    const startAuto = () => {
-      if (prefersReducedMotion || slides.length < 2) return;
-      stopAuto();
-      timerId = window.setInterval(next, 6000);
-    };
-
-    nextBtn?.addEventListener("click", () => {
-      stopAuto();
-      next();
-      startAuto();
-    });
-
-    prevBtn?.addEventListener("click", () => {
-      stopAuto();
-      prev();
-      startAuto();
-    });
-
-    dots.forEach((dot, idx) => {
-      dot.addEventListener("click", () => {
-        stopAuto();
-        setActive(idx);
-        startAuto();
-      });
-    });
-
-    container.addEventListener("mouseenter", stopAuto);
-    container.addEventListener("mouseleave", startAuto);
-
-    setActive(0);
-    startAuto();
-
-    state.carouselController = {
-      stop: stopAuto,
-    };
-  }
-
-  function attachCatalogHandlers() {
-    const catalog = document.getElementById("project-catalog");
-    if (!catalog) return;
-    catalog.addEventListener("click", (event) => {
-      const button = event.target.closest("[data-project]");
-      if (!button) return;
-      const id = button.getAttribute("data-project");
-      if (id && id !== state.activeId) {
-        state.activeId = id;
-        renderProjects();
-      }
-    });
-
-    catalog.addEventListener("keydown", (event) => {
-      if (event.key !== "Enter" && event.key !== " ") return;
-      const button = event.target.closest("[data-project]");
-      if (!button) return;
-      event.preventDefault();
-      const id = button.getAttribute("data-project");
-      if (id && id !== state.activeId) {
-        state.activeId = id;
-        renderProjects();
-      }
-    });
-  }
-
-  async function loadGuideGallery(project) {
-    try {
-      const response = await fetch(asset("guide-manifest.json"), {
-        cache: "no-cache",
-      });
-      if (!response.ok)
-        throw new Error(
-          `Unable to load guide-manifest.json (${response.status})`,
-        );
-      const manifest = await response.json();
-      if (!manifest?.entries) return;
-
-      const slides = [];
-      for (const entry of manifest.entries) {
-        if (entry.type !== "image") continue;
-        const resolved = await resolveGuideImage(entry.src);
-        if (!resolved) continue;
-        slides.push({ src: resolved, alt: entry.alt, caption: entry.caption });
-      }
-
-      if (slides.length) {
-        project.gallery = slides;
-        if (project.id === "guide") {
-          state.guideMediaSlides = slides;
-        }
-        if (!project.heroImage) {
-          project.heroImage = slides[0].src;
-        }
-        if (project.id === state.activeId) {
-          renderProjects();
-        }
-      }
-    } catch (error) {
-      console.warn("Unable to hydrate guide media", error);
-    }
-  }
-
-  function resolveGuideImage(rawSrc) {
-    const decoded = decodeURIComponent(rawSrc || "").trim();
-    const fileName = decoded.split(/[\\/]/).pop() || "";
-    const lower = fileName.toLowerCase();
-    const base = lower.replace(/\.[^.]+$/, "");
-    const extMatch = lower.match(/\.[^.]+$/);
-    const defaultExt = extMatch ? extMatch[0] : ".png";
-    const normalized = base.replace(/\s+/g, "-").replace(/_/g, "-");
-    const dashed = normalized.replace(
-      /^(guide|gr)(-?)(\d{1,2})$/,
-      (_, prefix, __, digits) => `${prefix}-${digits.padStart(2, "0")}`,
-    );
-
-    const candidates = new Set();
-    [normalized, dashed]
-      .filter((value) => Boolean(value))
-      .forEach((variant) => {
-        [".png", ".PNG", ".jpg", ".JPG", ".jpeg", ".JPEG", defaultExt].forEach(
-          (ext) => {
-            candidates.add(`${variant}${ext}`);
-          },
-        );
-      });
-    candidates.add(fileName);
-
-    const prefix = `${repoBase}public/images/guide/`;
-    const list = Array.from(candidates).map(
-      (name) => `${prefix}${name.replace(/^\/+/, "")}`,
-    );
-
-    return new Promise((resolve) => {
-      if (!list.length) {
-        resolve(null);
-        return;
-      }
-      let index = 0;
-      const tryNext = () => {
-        if (index >= list.length) {
-          resolve(null);
-          return;
-        }
-        const testImage = new Image();
-        testImage.onload = () => resolve(list[index]);
-        testImage.onerror = () => {
-          index += 1;
-          tryNext();
-        };
-        testImage.src = list[index];
-      };
-      tryNext();
+    container.addEventListener("click", (event) => {
+      const tile = event.target.closest(".project-tile");
+      if (!tile) return;
+      const projectId = tile.getAttribute("data-project-id");
+      if (!projectId || projectId === state.activeId) return;
+      state.activeId = projectId;
+      renderProjectTiles();
+      renderProjectDetail();
     });
   }
 
@@ -888,9 +634,7 @@
     };
 
     toggle.addEventListener("click", toggleMenu);
-    closeButtons.forEach((button) =>
-      button.addEventListener("click", closeMenu),
-    );
+    closeButtons.forEach((button) => button.addEventListener("click", closeMenu));
     backdrop?.addEventListener("click", closeMenu);
     panel.addEventListener("click", (event) => {
       if (event.target.matches("a")) {
@@ -898,10 +642,7 @@
       }
     });
     document.addEventListener("keydown", (event) => {
-      if (
-        event.key === "Escape" &&
-        document.body.classList.contains("menu-open")
-      ) {
+      if (event.key === "Escape" && document.body.classList.contains("menu-open")) {
         closeMenu();
       }
     });
@@ -910,16 +651,12 @@
   function init() {
     applyLocalImages();
     attachRevealObserver();
-    renderProjects();
-    attachCatalogHandlers();
+    renderProjectTiles();
+    renderProjectDetail();
+    mountProjectInteractions();
     renderTestimonials();
     updateYear();
     setupMenuToggle();
-
-    const guideProject = projects.find((project) => project.galleryManifest);
-    if (guideProject) {
-      loadGuideGallery(guideProject);
-    }
   }
 
   if (document.readyState === "loading") {


### PR DESCRIPTION
## Summary
- simplify the header/hamburger styling and replace the hero copy with the requested messaging while adding new skills and contact sections
- rebuild the portfolio area around three vertical tiles that drive a tabbed detail view with metrics and carousel media

## Testing
- Not run (static UI changes)


------
https://chatgpt.com/codex/tasks/task_e_6909555db0a883229bc46247c954ec2e